### PR TITLE
Setup build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# cmake build directory
+build
+# Generated waveform
+*.fst
+*.vcd
+# Generated firmware
+*.bin
+*.hex

--- a/sim/picorv32-main/CMakeLists.txt
+++ b/sim/picorv32-main/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required (VERSION 3.16)
+
+project(picorv32)
+
+find_package(verilator)
+
+add_library(picorv32_axi)
+
+verilate(
+    picorv32_axi
+    SOURCES picorv32.v
+    TOP_MODULE picorv32_axi
+    OUTPUT_DIRECTORY picorv32_axi
+    TRACE_FST
+)
+


### PR DESCRIPTION
Add basic CMake build system to picorv32. The executable build will follow.